### PR TITLE
Restore headers with source acknowledgements

### DIFF
--- a/post-receive
+++ b/post-receive
@@ -2,6 +2,11 @@
 #
 # Slack (slack.com) notification post-receive hook.
 #
+# Based on: https://github.com/joemiller/git-hooks Campfire notification post-receive hook. Author: Joe Miller
+# (http://joemiller.me)
+#
+# Based on post-receive.irc by Mikael Fridh <frimik@gmail.com> https://gist.github.com/1821358
+#
 # Settings needed:
 #  git config hooks.slack.webhook-url "https://hooks.slack.com/services/..."
 #  git config hooks.slack.channel "general"


### PR DESCRIPTION
This was destructively resubmitted, removing all original credits.
See also https://github.com/chriseldredge/git-slack-hook